### PR TITLE
feat: deploy linkding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.envrc
+kubeconfig

--- a/apps/base/linkding/deployment.yaml
+++ b/apps/base/linkding/deployment.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: linkding
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: linkding
+  template:
+    metadata:
+      labels:
+        app: linkding
+    spec:
+      containers:
+        - name: linkding
+          image: sissbruecker/linkding:1.31.0
+          ports:

--- a/apps/base/linkding/kustomization.yaml
+++ b/apps/base/linkding/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8.io/v1beta
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - deployment.yaml

--- a/apps/base/linkding/namespace.yaml
+++ b/apps/base/linkding/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: linkding

--- a/apps/staging/linkding/kustomization.yaml
+++ b/apps/staging/linkding/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta
+kind: Kustomization
+namespace: linkding
+resources:
+  - ../../base/linkding

--- a/clusters/staging/apps.yaml
+++ b/clusters/staging/apps.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: apps
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  retryInterval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./apps/staging
+  prune: true


### PR DESCRIPTION
- Add .gitignore file to ignore .envrc and kubeconfig
- Add deployment.yaml for linkding deployment configuration
- Add kustomization.yaml to manage linkding resources
- Add namespace.yaml to define linkding namespace
- Add kustomization.yaml for staging environment
- Add apps.yaml for staging cluster configuration